### PR TITLE
Fix path normalization to handle backslashes in texture file paths and safe file deletion to prevent errors on Linux

### DIFF
--- a/lib/TexturesLoading.as
+++ b/lib/TexturesLoading.as
@@ -14,6 +14,10 @@ namespace TexturesLoading {
     string updateOne = "";
     bool reloadModWorkPictures = false;
 
+    string NormalizePath(const string &in path) {
+        return path.Replace("\\", "/");
+    }
+
     /*
         Update all textures
     */
@@ -93,8 +97,8 @@ namespace TexturesLoading {
 
         if(modMethod == "Modless") {
             ModlessManager::SetTexture(cachedFile, file);
-        } else if(modMethod == "ModWork") { 
-            CopyFile(cachedFile, ModWorkManager::GetCurrentFolder() + "/" + file); 
+        } else if(modMethod == "ModWork") {
+            CopyFile(cachedFile, ModWorkManager::GetCurrentFolder() + "/" + file);
         }
     }
 
@@ -105,18 +109,18 @@ namespace TexturesLoading {
         displayTexturesLoading = true && !isSilent;
         RestartPrompt::displayRestartPrompt = false;
         total = files.Length;
-        currentMaterial = material; 
+        currentMaterial = material;
         for(uint i = 0; i < files.Length; i++) {
             progress = i +1;
             currentFile = string(files[i]);
-            const string path = ModWorkManager::GetCurrentFolder() + "/" + currentFile;
+            const string path = NormalizePath(ModWorkManager::GetCurrentFolder() + "/" + currentFile);
             // If preset is Default, we don't download any texture, unless custom textures were applied before
             if((preset != "Default" || (modMethod == "Modless" && !isSilent)) || hasPreviousTextures.Find(material) > -1) {
                 if(modMethod == "ModWork") {
                     IO::Delete(path);
                 }
                 DownloadTexture(quality, material, preset, currentFile, isSilent);
-            }   
+            }
         }
 
         /* Managing old/new wood textures is only available with the ModWork method */
@@ -131,22 +135,22 @@ namespace TexturesLoading {
                     } else if(currentFile.Contains('_NewWood') && woodTexture == "new") {
                         const string baseFile = currentFile.Replace('_NewWood', "");
                         TexturesLoading::ExchangeFiles(baseFile, currentFile);
-                    } 
+                    }
                 }
             }
         }
-        
+
         displayTexturesLoading = false;
-        
+
         auto app = cast<CTrackMania>(GetApp());
         if(app.RootMap !is null && changeRestartPromptStatus) {
             RestartPrompt::displayRestartPrompt = true && !isSilent;
-        } else if(!isSilent && modMethod == "Modless") {  
+        } else if(!isSilent && modMethod == "Modless") {
             startnew(ModlessManager::ReloadMap);
         }
-        
+
     }
-    
+
     /*
         Render view to let the user know about texture download status
     */

--- a/lib/TexturesLoading.as
+++ b/lib/TexturesLoading.as
@@ -117,7 +117,13 @@ namespace TexturesLoading {
             // If preset is Default, we don't download any texture, unless custom textures were applied before
             if((preset != "Default" || (modMethod == "Modless" && !isSilent)) || hasPreviousTextures.Find(material) > -1) {
                 if(modMethod == "ModWork") {
-                    IO::Delete(path);
+                    trace("Full file path: " + path);
+                    if (IO::FileExists(path)) {
+                        IO::Delete(path);
+                        trace("[Delete] Removed: " + path);
+                    } else {
+                        warn("[Delete] File not found, skipping: " + path);
+                    }
                 }
                 DownloadTexture(quality, material, preset, currentFile, isSilent);
             }


### PR DESCRIPTION
Hello, This PR fixes two related issues affecting texture file handling on Linux:

1. **Path normalization:**  
   Texture file paths in `TextureLoading.as` are constructed using mixed or Windows-style backslashes (`\`), causing file I/O     errors on Linux systems. paths must use forward slashes (`/`).  The fix normalizes all file and folder paths by replacing backslashes with forward slashes before any file operations.

2. **Safe file deletion:**  
   The plugin was attempting to delete files that do not exist, causing unnecessary I/O errors.  
   The fix wraps all file deletions with existence checks (`IO::FileExists()`) to avoid trying to delete missing files and to reduce error noise.


### Example output before the fix:
[Delete] Failed to delete file: C:\Users\steamuser\Documents\Trackmania\Skins\Stadium\ModWork\Image/Grass_D.dds
Warning: IO error - file not found

### How the above path is constructed incorrectly:
string folder = "C:\\Users\\steamuser\\Documents\\Trackmania\\Skins\\Stadium\\ModWork\\Image";
string file = "Grass_D.dds";

string fullPath = folder + "/" + file;
// Result: "C:\\Users\\steamuser\\Documents\\Trackmania\\Skins\\Stadium\\ModWork\\Image/Grass_D.dds"

### The Fix:
**Wrap `fullPath` construction from above with a  `NormalizePath` call to sanitize input**:
string fullPath = NormalizePath(folder + "/" + file);
// Result: "C:/Users/steamuser/Documents/Trackmania/Skins/Stadium/ModWork/Image/Grass_D.dds"

I tested this in Developer mode on latest Trackmania 2020 release as of writing this PR, seems to work fine on Linux now with the ModWork option. Hope this gets merged so I don't need to manually load my local unsigned plugin lol.